### PR TITLE
refactor: extract the core logic of volume.Ls into an exported function

### DIFF
--- a/pkg/cmd/volume/ls.go
+++ b/pkg/cmd/volume/ls.go
@@ -44,21 +44,6 @@ type volumePrintable struct {
 }
 
 func Ls(options *types.VolumeLsCommandOptions, stdout io.Writer) error {
-	lsSanitizeInput(options)
-	vols, err := List(
-		options.GOptions.Namespace,
-		options.GOptions.DataRoot,
-		options.GOptions.Address,
-		options.Size,
-		options.Filters,
-	)
-	if err != nil {
-		return err
-	}
-	return lsPrintOutput(options, stdout, vols)
-}
-
-func lsSanitizeInput(options *types.VolumeLsCommandOptions) {
 	if options.Quiet && options.Size {
 		logrus.Warn("cannot use --size and --quiet together, ignoring --size")
 		options.Size = false
@@ -72,6 +57,17 @@ func lsSanitizeInput(options *types.VolumeLsCommandOptions) {
 		logrus.Warn("should use --filter=size and --size together")
 		options.Size = true
 	}
+	vols, err := List(
+		options.GOptions.Namespace,
+		options.GOptions.DataRoot,
+		options.GOptions.Address,
+		options.Size,
+		options.Filters,
+	)
+	if err != nil {
+		return err
+	}
+	return lsPrintOutput(options, stdout, vols)
 }
 
 func hasSizeFilter(filters []string) bool {

--- a/pkg/cmd/volume/ls.go
+++ b/pkg/cmd/volume/ls.go
@@ -57,6 +57,7 @@ func Ls(options *types.VolumeLsCommandOptions, stdout io.Writer) error {
 		logrus.Warn("should use --filter=size and --size together")
 		options.Size = true
 	}
+
 	vols, err := List(
 		options.GOptions.Namespace,
 		options.GOptions.DataRoot,

--- a/pkg/cmd/volume/ls.go
+++ b/pkg/cmd/volume/ls.go
@@ -44,22 +44,86 @@ type volumePrintable struct {
 }
 
 func Ls(options *types.VolumeLsCommandOptions, stdout io.Writer) error {
+	lsSanitizeInput(options)
+	vols, err := LsGetData(&LsGetDataOptions{
+		Namespace: options.GOptions.Namespace,
+		DataRoot:  options.GOptions.DataRoot,
+		Address:   options.GOptions.Address,
+		Size:      options.Size,
+		Filters:   options.Filters,
+	})
+	if err != nil {
+		return err
+	}
+	return lsPrintOutput(options, stdout, vols)
+}
+
+func lsSanitizeInput(options *types.VolumeLsCommandOptions) {
 	if options.Quiet && options.Size {
 		logrus.Warn("cannot use --size and --quiet together, ignoring --size")
 		options.Size = false
 	}
-	labelFilterFuncs, nameFilterFuncs, sizeFilterFuncs, isFilter, err := getVolumeFilterFuncs(options.Filters)
-	if err != nil {
-		return err
-	}
-	if len(sizeFilterFuncs) > 0 && options.Quiet {
+	sizeFilter := hasSizeFilter(options.Filters)
+	if sizeFilter && options.Quiet {
 		logrus.Warn("cannot use --filter=size and --quiet together, ignoring --filter=size")
-		sizeFilterFuncs = nil
+		options.Filters = removeSizeFilters(options.Filters)
 	}
-	if len(sizeFilterFuncs) > 0 && !options.Size {
+	if sizeFilter && !options.Size {
 		logrus.Warn("should use --filter=size and --size together")
 		options.Size = true
 	}
+}
+
+func hasSizeFilter(filters []string) bool {
+	for _, filter := range filters {
+		if strings.HasPrefix(filter, "size") {
+			return true
+		}
+	}
+	return false
+}
+
+func removeSizeFilters(filters []string) []string {
+	var res []string
+	for _, filter := range filters {
+		if !strings.HasPrefix(filter, "size") {
+			res = append(res, filter)
+		}
+	}
+	return res
+}
+
+// LsGetDataOptions is created so that the caller of LsGetData
+// do not need to depend on irrelevant things in VolumeLsCommandOptions (e.g., Format).
+type LsGetDataOptions struct {
+	Namespace string
+	DataRoot  string
+	Address   string
+	Size      bool
+	Filters   []string
+}
+
+// LsGetData contains the main logic and can be used by projects other than CLIs.
+// If improvements are added (e.g., filtering by dangling=true, driver=local, etc.),
+// other projects can also benefit from this.
+func LsGetData(options *LsGetDataOptions) (map[string]native.Volume, error) {
+	labelFilterFuncs, nameFilterFuncs, sizeFilterFuncs, isFilter, err := getVolumeFilterFuncs(options.Filters)
+	if err != nil {
+		return nil, err
+	}
+	vols, err := Volumes(options.Namespace, options.DataRoot, options.Address, options.Size)
+	if err != nil {
+		return nil, err
+	}
+	for k, v := range vols {
+		if isFilter && !volumeMatchesFilter(v, labelFilterFuncs, nameFilterFuncs, sizeFilterFuncs) {
+			delete(vols, k)
+		}
+	}
+	return vols, nil
+}
+
+func lsPrintOutput(options *types.VolumeLsCommandOptions, stdout io.Writer, vols map[string]native.Volume) error {
 	w := stdout
 	var tmpl *template.Template
 	switch options.Format {
@@ -85,15 +149,7 @@ func Ls(options *types.VolumeLsCommandOptions, stdout io.Writer) error {
 		}
 	}
 
-	vols, err := Volumes(options.GOptions.Namespace, options.GOptions.DataRoot, options.GOptions.Address, options.Size)
-	if err != nil {
-		return err
-	}
-
 	for _, v := range vols {
-		if isFilter && !volumeMatchesFilter(v, labelFilterFuncs, nameFilterFuncs, sizeFilterFuncs) {
-			continue
-		}
 		p := volumePrintable{
 			Driver:     "local",
 			Labels:     "",
@@ -112,7 +168,7 @@ func Ls(options *types.VolumeLsCommandOptions, stdout io.Writer) error {
 			if err := tmpl.Execute(&b, p); err != nil {
 				return err
 			}
-			if _, err = fmt.Fprintf(w, b.String()+"\n"); err != nil {
+			if _, err := fmt.Fprintf(w, b.String()+"\n"); err != nil {
 				return err
 			}
 		} else if options.Quiet {

--- a/pkg/cmd/volume/ls.go
+++ b/pkg/cmd/volume/ls.go
@@ -45,13 +45,13 @@ type volumePrintable struct {
 
 func Ls(options *types.VolumeLsCommandOptions, stdout io.Writer) error {
 	lsSanitizeInput(options)
-	vols, err := LsGetData(&LsGetDataOptions{
-		Namespace: options.GOptions.Namespace,
-		DataRoot:  options.GOptions.DataRoot,
-		Address:   options.GOptions.Address,
-		Size:      options.Size,
-		Filters:   options.Filters,
-	})
+	vols, err := List(
+		options.GOptions.Namespace,
+		options.GOptions.DataRoot,
+		options.GOptions.Address,
+		options.Size,
+		options.Filters,
+	)
 	if err != nil {
 		return err
 	}
@@ -93,25 +93,15 @@ func removeSizeFilters(filters []string) []string {
 	return res
 }
 
-// LsGetDataOptions is created so that the caller of LsGetData
-// do not need to depend on irrelevant things in VolumeLsCommandOptions (e.g., Format).
-type LsGetDataOptions struct {
-	Namespace string
-	DataRoot  string
-	Address   string
-	Size      bool
-	Filters   []string
-}
-
-// LsGetData contains the main logic and can be used by projects other than CLIs.
+// List contains the main logic and can be used by projects other than CLIs.
 // If improvements are added (e.g., filtering by dangling=true, driver=local, etc.),
 // other projects can also benefit from this.
-func LsGetData(options *LsGetDataOptions) (map[string]native.Volume, error) {
-	labelFilterFuncs, nameFilterFuncs, sizeFilterFuncs, isFilter, err := getVolumeFilterFuncs(options.Filters)
+func List(namespace, dataRoot, address string, size bool, filters []string) (map[string]native.Volume, error) {
+	labelFilterFuncs, nameFilterFuncs, sizeFilterFuncs, isFilter, err := getVolumeFilterFuncs(filters)
 	if err != nil {
 		return nil, err
 	}
-	vols, err := Volumes(options.Namespace, options.DataRoot, options.Address, options.Size)
+	vols, err := Volumes(namespace, dataRoot, address, size)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/volume/ls.go
+++ b/pkg/cmd/volume/ls.go
@@ -89,26 +89,6 @@ func removeSizeFilters(filters []string) []string {
 	return res
 }
 
-// List contains the main logic and can be used by projects other than CLIs.
-// If improvements are added (e.g., filtering by dangling=true, driver=local, etc.),
-// other projects can also benefit from this.
-func List(namespace, dataRoot, address string, size bool, filters []string) (map[string]native.Volume, error) {
-	labelFilterFuncs, nameFilterFuncs, sizeFilterFuncs, isFilter, err := getVolumeFilterFuncs(filters)
-	if err != nil {
-		return nil, err
-	}
-	vols, err := Volumes(namespace, dataRoot, address, size)
-	if err != nil {
-		return nil, err
-	}
-	for k, v := range vols {
-		if isFilter && !volumeMatchesFilter(v, labelFilterFuncs, nameFilterFuncs, sizeFilterFuncs) {
-			delete(vols, k)
-		}
-	}
-	return vols, nil
-}
-
 func lsPrintOutput(options *types.VolumeLsCommandOptions, stdout io.Writer, vols map[string]native.Volume) error {
 	w := stdout
 	var tmpl *template.Template
@@ -169,6 +149,26 @@ func lsPrintOutput(options *types.VolumeLsCommandOptions, stdout io.Writer, vols
 		return f.Flush()
 	}
 	return nil
+}
+
+// List contains the main logic and can be used by projects other than CLIs.
+// If improvements are added (e.g., filtering by dangling=true, driver=local, etc.),
+// other projects can also benefit from this.
+func List(namespace, dataRoot, address string, size bool, filters []string) (map[string]native.Volume, error) {
+	labelFilterFuncs, nameFilterFuncs, sizeFilterFuncs, isFilter, err := getVolumeFilterFuncs(filters)
+	if err != nil {
+		return nil, err
+	}
+	vols, err := Volumes(namespace, dataRoot, address, size)
+	if err != nil {
+		return nil, err
+	}
+	for k, v := range vols {
+		if isFilter && !volumeMatchesFilter(v, labelFilterFuncs, nameFilterFuncs, sizeFilterFuncs) {
+			delete(vols, k)
+		}
+	}
+	return vols, nil
 }
 
 func Volumes(ns string, dataRoot string, address string, volumeSize bool) (map[string]native.Volume, error) {


### PR DESCRIPTION
`volume.Ls` does 3 things:

1. Sanitize the input according to the nerdctl CLI logic (e.g., `"cannot use --size and --quiet together, ignoring --size"`).
2. The core logic: convert the human-readable filter strings into filter functions, apply them to the volumes, and return the resulting volumes.
3. Print the resulting volumes.

This PR extracts the core logic (i.e., step 2) into an exported function so that it can be reused by other projects, potentially not CLI ones, and they can have their own input validation logic and output format.

Appreciate any suggestion, thanks!